### PR TITLE
Fix argument name for PySR model predictions

### DIFF
--- a/gold_miner_spread.py
+++ b/gold_miner_spread.py
@@ -90,7 +90,7 @@ model.fit(train_features.values, train_targets.values)
 top_equations = model.equations_.sort_values("loss").head(10)
 pred_list = []
 for idx in top_equations.index:
-    pred_list.append(model.predict(test_features.values, model=idx))
+    pred_list.append(model.predict(test_features.values, index=idx))
 raw_preds = np.mean(np.column_stack(pred_list), axis=1)
 
 # Align correlation filter to prediction index


### PR DESCRIPTION
## Summary
- update `model.predict` call to use `index` argument for selecting a model

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python gold_miner_spread.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686b370e324083329a370d46e6663407