### PR TITLE
Fix returns alignment in backtest

### DIFF
--- a/gold_miner_spread.py
+++ b/gold_miner_spread.py
@@ -97,10 +97,11 @@ raw_preds = np.mean(np.column_stack(pred_list), axis=1)
 filter_values = corr_filter_series.loc[test_targets.index].fillna(0).values
 
 # 10. Backtest Strategy
-returns = test_targets.diff().dropna().values
+returns = test_targets.diff().fillna(0).values
 n_preds = len(raw_preds)
 aligned_returns = returns[-n_preds:]
-signals = np.sign(raw_preds[:-1]) * filter_values[:-1]
+signals = np.sign(raw_preds[1:]) * filter_values[1:]
+assert len(signals) == len(aligned_returns[1:]), "signals and returns must be equal length"
 strategy_returns = signals * aligned_returns[1:]
 benchmark_returns = aligned_returns[1:]
 


### PR DESCRIPTION
## Summary
- correct slicing for strategy signals and returns
- add length assertion for safety
- ensure script ends with a newline

## Testing
- `python -m py_compile gold_miner_spread.py`
- `python gold_miner_spread.py` *(fails: KeyboardInterrupt during Julia package precompilation)*

------
https://chatgpt.com/codex/tasks/task_e_686b3a9a450c8332b02146cfa12187d8