### PR TITLE
Fix broadcasting error in filter_values

### DIFF
--- a/gold_miner_spread.py
+++ b/gold_miner_spread.py
@@ -107,7 +107,12 @@ for idx in top_equations.index:
 raw_preds = np.mean(np.column_stack(pred_list), axis=1)
 
 # Align correlation filter to prediction index
-filter_values = corr_filter_series.loc[test_targets.index].fillna(0).values
+filter_values = (
+    corr_filter_series.loc[test_targets.index]
+    .fillna(0)
+    .to_numpy()
+    .ravel()
+)
 
 # 10. Backtest Strategy
 returns = test_targets.diff().fillna(0).values


### PR DESCRIPTION
## Summary
- ensure `filter_values` is converted to a 1D array before applying trading signals

## Testing
- `python -m py_compile gold_miner_spread.py`

------
https://chatgpt.com/codex/tasks/task_e_686b3f3bb7d883328442df424cdf5ec7