### PR TITLE
Add transaction cost modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,6 @@ The script downloads price data from Yahoo Finance and outputs a plot and summar
 statistics of the backtested strategy.
 
 The annualized return metric now uses a compounding approach based on the
-product of period returns.
+product of period returns. The strategy also subtracts transaction costs of
+5 basis points per trade from daily returns to better approximate real-world
+execution.

--- a/gold_miner_spread.py
+++ b/gold_miner_spread.py
@@ -141,6 +141,12 @@ assert len(signals) == len(aligned_returns[1:]), (
     "signals and returns must be equal length"
 )
 strategy_returns = signals * aligned_returns[1:]
+
+# Transaction costs (5 bps per buy/sell)
+tc_rate = 0.0005
+trade_costs = tc_rate * np.abs(np.diff(np.insert(signals, 0, 0)))
+strategy_returns -= trade_costs
+
 benchmark_returns = aligned_returns[1:]
 
 
@@ -165,6 +171,7 @@ def sharpe_ratio_func(returns, periods_per_year=252):
     )
 
 
+# Evaluate performance after transaction costs
 sharpe_ratio = sharpe_ratio_func(strategy_returns)
 
 # 11. Plot Cumulative Returns in Percent with Background Signal Coloring


### PR DESCRIPTION
## Summary
- include transaction costs of 5 bps per trade in the strategy
- note transaction costs in README

## Testing
- `pip install -r requirements.txt`
- `python gold_miner_spread.py` *(fails: KeyboardInterrupt during heavy PySR setup)*

------
https://chatgpt.com/codex/tasks/task_e_686bdc6602908332972214358268f5bd