### PR TITLE
Optimize correlation window

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ The annualized return metric now uses a compounding approach based on the
 product of period returns. The strategy also subtracts transaction costs of
 5 basis points per trade from daily returns to better approximate real-world
 execution.
+
+The correlation filter now automatically selects the best rolling window
+length by testing multiple candidates and choosing the one with the highest
+average absolute correlation between GLD and GDX returns.

--- a/gold_miner_spread.py
+++ b/gold_miner_spread.py
@@ -76,6 +76,18 @@ def rolling_corr_change(series1, series2, window=15):
     return (corr_change < 0).astype(int)
 
 
+def optimal_corr_window(series1, series2, windows):
+    """Return the window length with the highest mean absolute correlation."""
+    best_window = None
+    best_score = -np.inf
+    for w in windows:
+        corr = series1.rolling(w).corr(series2).abs().mean()
+        if corr > best_score:
+            best_score = corr
+            best_window = w
+    return best_window
+
+
 # 5. Load GDX and GLD data
 gdx = load_data("GDX")
 gld = load_data("GLD")
@@ -83,7 +95,10 @@ gld = load_data("GLD")
 # Rolling correlation change between GLD and GDX returns
 gdx_ret = gdx.pct_change()
 gld_ret = gld.pct_change()
-corr_filter_series = rolling_corr_change(gld_ret, gdx_ret)
+candidate_windows = range(10, 31, 5)
+best_window = optimal_corr_window(gld_ret, gdx_ret, candidate_windows)
+corr_filter_series = rolling_corr_change(gld_ret, gdx_ret, window=best_window)
+print(f"Optimal correlation window: {best_window}")
 
 # 6. Calculate spread using formula provided
 aligned = pd.concat([gld, gdx], axis=1, join='inner')


### PR DESCRIPTION
## Summary
- tune rolling correlation window by scanning candidate sizes
- print window length used
- clarify documentation for the new optimization

## Testing
- `python -m py_compile gold_miner_spread.py`
- *(tests that require `pysr` were unable to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686be5c7dab083328b0cca1189a1c811