### PR TITLE
Add tournament selection to symbolic regressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ execution.
 The correlation filter now automatically selects the best rolling window
 length by testing multiple candidates and choosing the one with the highest
 average absolute correlation between GLD and GDX returns.
+
+The symbolic regressor now uses tournament selection with a tournament size of
+20 and a 75% mutation probability. The search runs for up to 10,000
+iterations with a reduced maximum equation size of 6.

--- a/gold_miner_spread.py
+++ b/gold_miner_spread.py
@@ -119,13 +119,15 @@ test_targets = test_series[test_features.index]
 
 # 8. Symbolic Regressor
 model = PySRRegressor(
-    niterations=100,
+    niterations=10000,
     binary_operators=["+", "-", "*", "/"],
     unary_operators=["sin", "cos", "exp", "log"],
     population_size=1000,
     model_selection="best",
     loss="L2DistLoss()",
-    maxsize=20,
+    maxsize=6,
+    tournament_selection_n=20,
+    crossover_probability=0.25,
     verbosity=1,
     random_state=42
 )


### PR DESCRIPTION
## Summary
- use tournament selection and set mutation/crossover probability
- reduce expression size to 6
- increase iterations to 10,000
- document the new symbolic regressor configuration

## Testing
- `pip install -r requirements.txt` *(fails: Running pip as the root user. Installs packages successfully)*
- `python gold_miner_spread.py` *(fails: KeyboardInterrupt during Julia setup)*

------
https://chatgpt.com/codex/tasks/task_e_686bf0af3db88332bf485e905988f7c1