### PR TITLE
Improve trading logic with persistent positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ The correlation filter now automatically selects the best rolling window
 length by testing multiple candidates and choosing the one with the highest
 average absolute correlation between GLD and GDX returns.
 
+When the model forecasts the spread direction, the position is only updated if
+the prior day's change in correlation is negative. Otherwise the strategy
+maintains its existing exposure. Transaction costs are only charged when this
+position changes.
+
 The symbolic regressor now uses tournament selection with a tournament size of
 20 and a 75% mutation probability. The search runs for up to 10,000
 iterations with a reduced maximum equation size of 6.


### PR DESCRIPTION
## Summary
- update backtest so correlation filter keeps prior position when it blocks a trade
- apply transaction costs only on position changes
- document the new logic in the README

## Testing
- `pip install -r requirements.txt`
- `python gold_miner_spread.py` *(fails: Julia installation for PySR requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_686db49795888332bda597f3fd846711