### PR TITLE
Add transactions column to return table

### DIFF
--- a/gold_miner_spread.py
+++ b/gold_miner_spread.py
@@ -176,6 +176,12 @@ tc_rate = 0.0005
 trade_costs = tc_rate * np.abs(np.diff(positions))
 strategy_returns -= trade_costs
 
+# Track the number of transactions executed by the strategy and the
+# benchmark. A position change from long to short counts as two
+# transactions, matching the transaction cost calculation above.
+num_transactions_strategy = int(np.sum(np.abs(np.diff(positions))))
+num_transactions_benchmark = 1
+
 # Buy and hold: open a long position on the spread on day 1 and keep it
 # for the rest of the period. We subtract the transaction cost for the
 # initial trade only.
@@ -284,6 +290,10 @@ metrics_df = pd.DataFrame({
     "Calmar Ratio": [
         calmar_ratio(strategy_returns),
         calmar_ratio(benchmark_returns),
+    ],
+    "Transactions": [
+        num_transactions_strategy,
+        num_transactions_benchmark,
     ]
 }, index=["Strategy", "Buy & Hold"])
 


### PR DESCRIPTION
## Summary
- track the number of transactions executed by the strategy and benchmark
- include transaction counts in the performance summary table

## Testing
- `python -m py_compile gold_miner_spread.py`
- `python gold_miner_spread.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686dbb90b7848332a0b6f39fdfd7c15f