### PR TITLE
Fix compounding for cumulative returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ python gold_miner_spread.py
 The script downloads price data from Yahoo Finance and outputs a plot and summary
 statistics of the backtested strategy.
 
-The annualized return metric now uses a compounding approach based on the
-product of period returns. The strategy also subtracts transaction costs of
-5 basis points per trade from daily returns to better approximate real-world
-execution.
+The annualized return metric and all cumulative returns now use a compounding
+approach based on the product of period returns. The strategy also subtracts
+transaction costs of 5 basis points per trade from daily returns to better
+approximate real-world execution.
 
 The correlation filter now automatically selects the best rolling window
 length by testing multiple candidates and choosing the one with the highest

--- a/gold_miner_spread.py
+++ b/gold_miner_spread.py
@@ -212,9 +212,9 @@ def sharpe_ratio_func(returns, periods_per_year=252):
 
 def max_drawdown(returns):
     """Return the maximum drawdown of a series of returns."""
-    cumulative = np.cumsum(returns)
+    cumulative = np.cumprod(1 + returns)
     running_max = np.maximum.accumulate(cumulative)
-    drawdowns = running_max - cumulative
+    drawdowns = 1 - cumulative / running_max
     return np.max(drawdowns)
 
 
@@ -230,8 +230,8 @@ def calmar_ratio(returns, periods_per_year=252):
 sharpe_ratio = sharpe_ratio_func(strategy_returns)
 
 # 11. Plot Cumulative Returns in Percent with Background Signal Coloring
-cumulative_strategy = np.cumsum(strategy_returns)
-cumulative_benchmark = np.cumsum(benchmark_returns)
+cumulative_strategy = np.cumprod(1 + strategy_returns) - 1
+cumulative_benchmark = np.cumprod(1 + benchmark_returns) - 1
 
 # Plot returns
 fig, ax = plt.subplots(figsize=(12, 6))


### PR DESCRIPTION
## Summary
- compute drawdown using compounded returns
- calculate cumulative strategy and benchmark returns multiplicatively
- clarify compounding note in README

## Testing
- `python -m py_compile gold_miner_spread.py`

------
https://chatgpt.com/codex/tasks/task_e_686dc103142c8332b5946e27c15b5cf5