### PR TITLE
Use dates for returns plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ python gold_miner_spread.py
 ```
 
 The script downloads price data from Yahoo Finance and outputs a plot and summary
-statistics of the backtested strategy.
+statistics of the backtested strategy. The cumulative returns chart now displays
+dates on the x-axis instead of the number of trading days for easier analysis.
 
 The annualized return metric and all cumulative returns now use a compounding
 approach based on the product of period returns. The strategy also subtracts


### PR DESCRIPTION
## Summary
- plot returns against actual trading dates instead of trading-day numbers
- mention the new date axis in the README

## Testing
- `python -m py_compile gold_miner_spread.py`

------
https://chatgpt.com/codex/tasks/task_e_68702c37b54883328a82499005eac4a4