### PR TITLE
Improve correlation window selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ transaction costs of 5 basis points per trade from daily returns to better
 approximate real-world execution.
 
 The correlation filter now automatically selects the best rolling window
-length by testing multiple candidates and choosing the one with the highest
-average absolute correlation between GLD and GDX returns.
+length by evaluating several candidates with a walk-forward process and
+choosing the one that delivers the highest out-of-sample Sharpe ratio.
 
 When the model forecasts the spread direction, the position is only updated if
 the prior day's change in correlation is negative. Otherwise the strategy


### PR DESCRIPTION
## Summary
- evaluate rolling correlation filter windows using walk-forward Sharpe ratio
- move utility metrics earlier so they can be reused
- mention new window selection method in README

## Testing
- `python -m py_compile gold_miner_spread.py`

------
https://chatgpt.com/codex/tasks/task_e_687594331af8833290d508461680f483